### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/simplespamblocker/forms.py
+++ b/simplespamblocker/forms.py
@@ -10,6 +10,6 @@ class ValidRegexField(forms.CharField):
         if value:
             try:
                 re.compile(value)
-            except re.error, e:
+            except re.error as e:
                 raise forms.ValidationError('Please input valid regexp: %s' % e)
         return value


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.