### PR TITLE
docs: fix simple typo, comaptible -> compatible

### DIFF
--- a/simplespamblocker/tests/middleware.py
+++ b/simplespamblocker/tests/middleware.py
@@ -27,7 +27,7 @@ DEFAULT_PROFILES_WITHOUT_METHOD = (
 
 def create_user():
     from django.contrib.auth.models import User
-    # comaptible under django 1.3
+    # compatible under django 1.3
     return User.objects.create_user('dummyuser', 'dummyuser@example.com', password='test')
 
 


### PR DESCRIPTION
There is a small typo in simplespamblocker/tests/middleware.py.

Should read `compatible` rather than `comaptible`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md